### PR TITLE
Add verbose and dryrun options to cluster shuffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ there are also some commands for managing topics, most of which merely wraps the
 `kafka-topics.sh` tool that is bundled with Kafka, but with a slightly different
 interface.
 
+The most notable difference is the `create` subcommand that has the ability to create
+a consistent hashing plan and assign it to the new topic during creation.
+
+```shell
+$ ktl topic create 'some.topic' --partitions 3 --replication_factor 3 --rack_aware_allocation -z localhost:2181/test
+```
+
 ## Copyright
 
 © 2015 Burt AB, see LICENSE.txt (BSD 3-Clause).

--- a/lib/ktl/reassignment_task.rb
+++ b/lib/ktl/reassignment_task.rb
@@ -9,7 +9,7 @@ module Ktl
       @logger = options[:logger] || NullLogger.new
     end
 
-    def execute
+    def execute(dryrun = false)
       if @reassigner.reassignment_in_progress?
         @logger.warn 'reassignment already in progress, exiting'
       else
@@ -22,7 +22,11 @@ module Ktl
         end
         if reassignment.size > 0
           @logger.info 'reassigning %d partitions' % reassignment.size
-          @reassigner.execute(reassignment)
+          if dryrun
+            @logger.info 'dryrun detected, skipping reassignment'
+          else
+            @reassigner.execute(reassignment)
+          end
         else
           @logger.warn 'empty reassignment, ignoring'
         end

--- a/lib/ktl/shuffle_plan.rb
+++ b/lib/ktl/shuffle_plan.rb
@@ -33,6 +33,16 @@ module Ktl
       reassignment_plan
     end
 
+    def generate_for_new_topic(topic, partition_count)
+      brokers = select_brokers
+      nr_replicas = @options[:replication_factor] || 1
+      assignment = assign_replicas_to_brokers(topic, brokers, partition_count, nr_replicas)
+      assignment.map do |pr|
+        partition, replicas = pr.elements
+        Scala::Collection::JavaConversions.as_java_iterable(replicas).to_a
+      end
+    end
+
     private
 
     def select_brokers

--- a/lib/ktl/shuffle_plan.rb
+++ b/lib/ktl/shuffle_plan.rb
@@ -5,6 +5,8 @@ module Ktl
     def initialize(zk_client, options = {})
       @zk_client = zk_client
       @options = options
+      @logger = options[:logger] || NullLogger.new
+      @log_plan = !!options[:log_plan]
     end
 
     def generate
@@ -26,6 +28,7 @@ module Ktl
           topic_partition = Kafka::TopicAndPartition.new(topic, partition)
           current_assignment = replica_assignments.apply(topic_partition)
           unless current_assignment == replicas
+            @logger.info "Moving #{topic_partition.topic},#{topic_partition.partition} from #{current_assignment} to #{replicas}" if @log_plan
             reassignment_plan += Scala::Tuple.new(topic_partition, replicas)
           end
         end

--- a/spec/ktl/shuffle_plan_spec.rb
+++ b/spec/ktl/shuffle_plan_spec.rb
@@ -158,6 +158,22 @@ module Ktl
         end
       end
     end
+
+    context 'generate_for_new_topic' do
+      let :options do
+        super.merge(replication_factor: replica_count)
+      end
+
+      it 'generates a nested list of broker ids for a new topic' do
+        assignments.each do |topic, assignment|
+          generated_plan = plan.generate_for_new_topic(topic, assignment.size)
+          expect(generated_plan.size).to eql(assignment.size)
+          generated_plan.each do |partition|
+            expect(partition.uniq.size).to eql(replica_count)
+          end
+        end
+      end
+    end
   end
 
   describe ShufflePlan do


### PR DESCRIPTION
This pull request adds two options to give more information to `cluster shuffle`, in order to make shuffle operations a bit more understandable.

* `--dryrun` will output all reassignments in the generated plan, without actually running it
* `--verbose` will output all assignments executed in the current run
