### PR TITLE
Generate topics with a shuffle plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ there are also some commands for managing topics, most of which merely wraps the
 `kafka-topics.sh` tool that is bundled with Kafka, but with a slightly different
 interface.
 
+The most notable difference is the `create` subcommand that has the ability to create
+a consistent hashing plan and assign it to the new topic during creation.
+
+```shell
+$ ktl topic create 'some.topic' --partitions 3 --replication_factor 3 --rack_aware_allocation -z localhost:2181/test
+```
+
 ## Copyright
 
 © 2015 Burt AB, see LICENSE.txt (BSD 3-Clause).

--- a/lib/ktl/shuffle_plan.rb
+++ b/lib/ktl/shuffle_plan.rb
@@ -33,6 +33,16 @@ module Ktl
       reassignment_plan
     end
 
+    def generate_for_new_topic(topic, partition_count)
+      brokers = select_brokers
+      nr_replicas = @options[:replication_factor] || 1
+      assignment = assign_replicas_to_brokers(topic, brokers, partition_count, nr_replicas)
+      assignment.map do |pr|
+        partition, replicas = pr.elements
+        Scala::Collection::JavaConversions.as_java_iterable(replicas).to_a
+      end
+    end
+
     private
 
     def select_brokers

--- a/spec/ktl/shuffle_plan_spec.rb
+++ b/spec/ktl/shuffle_plan_spec.rb
@@ -158,6 +158,22 @@ module Ktl
         end
       end
     end
+
+    context 'generate_for_new_topic' do
+      let :options do
+        super.merge(replication_factor: replica_count)
+      end
+
+      it 'generates a nested list of broker ids for a new topic' do
+        assignments.each do |topic, assignment|
+          generated_plan = plan.generate_for_new_topic(topic, assignment.size)
+          expect(generated_plan.size).to eql(assignment.size)
+          generated_plan.each do |partition|
+            expect(partition.uniq.size).to eql(replica_count)
+          end
+        end
+      end
+    end
   end
 
   describe ShufflePlan do


### PR DESCRIPTION
This PR allows the creation of topics with a Rack aware or Rendevous hashed assignment plan. This way there's no need to first create the topic and then immediately shuffle it.

Of course the `replica_assignment` option to topic creation does not understand the reassignment JSON format, but has a different, less readable version. The format is `part1_broker1:part1_broker2,part2_broker1:part2_broker2` - see [kafka.admin.TopicCommand](https://github.com/apache/kafka/blob/0.10.0/core/src/main/scala/kafka/admin/TopicCommand.scala#L313)