### PR TITLE
Two step broker reassignment

### DIFF
--- a/lib/ext/kafka.rb
+++ b/lib/ext/kafka.rb
@@ -134,12 +134,12 @@ module Kafka
     def self.get_broker_rack(zk_client, broker_id)
       broker_metadata = Kafka::Admin.get_broker_metadatas(zk_client, [broker_id]).first
       rack = broker_metadata.rack
-      unless rack.isDefined
+      unless rack.defined?
         raise "Broker #{broker_metadata.id} is missing rack information, unable to create rack aware shuffle plan."
       end
       rack.get
     rescue Java::KafkaAdmin::AdminOperationException => e
-      if e.message.match '--disable-rack-aware'
+      if e.message.include? '--disable-rack-aware'
         raise "Not all brokers have rack information. Unable to create rack aware shuffle plan."
       else
         raise e

--- a/lib/ktl/cluster.rb
+++ b/lib/ktl/cluster.rb
@@ -28,8 +28,8 @@ module Ktl
     end
 
     desc 'migrate-broker', 'Migrate partitions from one broker to another'
-    option :from, aliases: %w[-f], type: :numeric, required: true, desc: 'Broker ID of old leader'
-    option :to, aliases: %w[-t], type: :numeric, required: true, desc: 'Broker ID of new leader'
+    option :from, aliases: %w[-f], type: :array, required: true, desc: 'Broker IDs to migrate away from'
+    option :to, aliases: %w[-t], type: :array, required: true, desc: 'Broker IDs to migrate to'
     option :zookeeper, aliases: %w[-z], required: true, desc: 'ZooKeeper URI'
     option :limit, aliases: %w[-l], type: :numeric, desc: 'Max number of partitions to reassign at a time'
     option :verbose, aliases: %w[-v], desc: 'Verbose output'
@@ -38,8 +38,8 @@ module Ktl
     option :delay, type: :numeric, desc: 'Delay in seconds between continous reassignment iterations, default 5s'
     def migrate_broker
       with_zk_client do |zk_client|
-        old_leader, new_leader = options.values_at(:from, :to)
-        plan = MigrationPlan.new(zk_client, old_leader, new_leader, log_plan: options.verbose, logger: logger)
+        old_brokers, new_brokers = options.values_at(:from, :to)
+        plan = MigrationPlan.new(zk_client, old_brokers.map(&:to_i), new_brokers.map(&:to_i), log_plan: options.verbose, logger: logger)
         reassigner = create_reassigner(zk_client, options)
         execute_reassignment(reassigner, plan, options)
       end

--- a/lib/ktl/cluster.rb
+++ b/lib/ktl/cluster.rb
@@ -39,9 +39,9 @@ module Ktl
     def migrate_broker
       with_zk_client do |zk_client|
         old_leader, new_leader = options.values_at(:from, :to)
-        plan = MigrationPlan.new(zk_client, old_leader, new_leader)
+        plan = MigrationPlan.new(zk_client, old_leader, new_leader, log_plan: options.verbose, logger: logger)
         reassigner = create_reassigner(zk_client, options)
-        execute_reassignment(reassigner, plan)
+        execute_reassignment(reassigner, plan, options)
       end
     end
 
@@ -75,7 +75,7 @@ module Ktl
           log_plan: options.dryrun,
         })
         reassigner = create_reassigner(zk_client, options)
-        execute_reassignment(reassigner, plan, options.dryrun)
+        execute_reassignment(reassigner, plan, options)
       end
     end
 
@@ -95,7 +95,7 @@ module Ktl
           plan = DecommissionPlan.new(zk_client, broker_id.to_i)
         end
         reassigner = create_reassigner(zk_client, options)
-        execute_reassignment(reassigner, plan)
+        execute_reassignment(reassigner, plan, options)
       end
     end
 
@@ -111,8 +111,8 @@ module Ktl
 
     private
 
-    def execute_reassignment(reassigner, plan, dryrun = false)
-      ReassignmentTask.new(reassigner, plan, shell, logger: logger).execute(dryrun)
+    def execute_reassignment(reassigner, plan, options)
+      ReassignmentTask.new(reassigner, plan, shell, logger: logger).execute(options.dryrun)
     end
 
     def create_reassigner(zk_client, options)

--- a/lib/ktl/continous_reassigner.rb
+++ b/lib/ktl/continous_reassigner.rb
@@ -29,7 +29,7 @@ module Ktl
       parsed_data = JSON.parse(data)
       if (partitions = parsed_data['partitions'])
         partitions = partitions.map { |r| r.values_at('topic', 'partition').join(':') }
-        @logger.info sprintf('%d partitions left to reassign (%p)', partitions.size, partitions)
+        @logger.debug sprintf('%d partitions left to reassign (%p)', partitions.size, partitions.size <= 5 ? partitions : '...')
       else
         @logger.info sprintf('Data without `partitions` key: %p', parsed_data)
       end

--- a/lib/ktl/continous_reassigner.rb
+++ b/lib/ktl/continous_reassigner.rb
@@ -49,16 +49,5 @@ module Ktl
         reassign(reassignment)
       end
     end
-
-    private
-
-    def reassign(reassignment)
-      reassignments = split(reassignment, @limit)
-      actual_reassignment = reassignments.shift
-      json = reassignment_json(actual_reassignment)
-      @zk_client.reassign_partitions(json)
-      manage_overflow(reassignments)
-      manage_progress_state(actual_reassignment)
-    end
   end
 end

--- a/lib/ktl/migration_plan.rb
+++ b/lib/ktl/migration_plan.rb
@@ -8,7 +8,7 @@ module Ktl
       @to_brokers = to_brokers
       if @from_brokers.length != @to_brokers.length
         raise "Both brokers lists must be of equal length. From: #{@from_brokers}, To: #{@to_brokers}"
-      elsif (@from_brokers + @to_brokers).uniq.length != @from_brokers.length * 2
+      elsif !(@from_brokers & @to_brokers).empty?
         raise "Broker lists must be mutually exclusive. From: #{@from_brokers}, To: #{@to_brokers}"
       end
       from_racks = from_brokers.map {|broker_id| Kafka::Admin.get_broker_rack(zk_client, broker_id)}

--- a/lib/ktl/migration_plan.rb
+++ b/lib/ktl/migration_plan.rb
@@ -2,10 +2,10 @@
 
 module Ktl
   class MigrationPlan
-    def initialize(zk_client, old_leader, new_leader, options = {})
+    def initialize(zk_client, old_replica, new_replica, options = {})
       @zk_client = zk_client
-      @old_leader = old_leader.to_java
-      @new_leader = new_leader.to_java
+      @old_replica = old_replica.to_java
+      @new_replica = new_replica.to_java
       @options = options
       @logger = options[:logger] || NullLogger.new
       @log_plan = !!options[:log_plan]
@@ -18,9 +18,9 @@ module Ktl
       assignments.each do |item|
         topic_partition = item.first
         replicas = item.last
-        if replicas.contains?(@old_leader)
-          index = replicas.index_of(@old_leader)
-          new_replicas = replicas.updated(index, @new_leader, CanBuildFrom)
+        if replicas.contains?(@old_replica)
+          index = replicas.index_of(@old_replica)
+          new_replicas = replicas.updated(index, @new_replica, CanBuildFrom)
           @logger.info "Moving #{topic_partition.topic},#{topic_partition.partition} from #{replicas} to #{new_replicas}" if @log_plan
           plan += Scala::Tuple.new(topic_partition, new_replicas)
         end

--- a/lib/ktl/migration_plan.rb
+++ b/lib/ktl/migration_plan.rb
@@ -2,11 +2,15 @@
 
 module Ktl
   class MigrationPlan
-    def initialize(zk_client, old_replica, new_replica, options = {})
+    def initialize(zk_client, from_brokers, to_brokers, options = {})
       @zk_client = zk_client
-      @old_replica = old_replica.to_java
-      @new_replica = new_replica.to_java
-      @options = options
+      @from_brokers = from_brokers
+      @to_brokers = to_brokers
+      if @from_brokers.length != @to_brokers.length
+        raise "Both brokers lists must be of equal length. From: #{@from_brokers}, To: #{@to_brokers}"
+      elsif (@from_brokers + @to_brokers).uniq.length != @from_brokers.length * 2
+        raise "Broker lists must be mutually exclusive. From: #{@from_brokers}, To: #{@to_brokers}"
+      end
       @logger = options[:logger] || NullLogger.new
       @log_plan = !!options[:log_plan]
     end
@@ -18,10 +22,16 @@ module Ktl
       assignments.each do |item|
         topic_partition = item.first
         replicas = item.last
-        if replicas.contains?(@old_replica)
-          index = replicas.index_of(@old_replica)
-          new_replicas = replicas.updated(index, @new_replica, CanBuildFrom)
-          @logger.info "Moving #{topic_partition.topic},#{topic_partition.partition} from #{replicas} to #{new_replicas}" if @log_plan
+        new_replicas = replicas
+        @from_brokers.each_with_index do |from_broker, index|
+          to_broker = @to_brokers[index]
+          if new_replicas.contains?(from_broker)
+            replacement_index = new_replicas.index_of(from_broker)
+            new_replicas = new_replicas.updated(replacement_index, to_broker, CanBuildFrom)
+          end
+        end
+        if replicas != new_replicas
+          @logger.debug "Moving #{topic_partition.topic},#{topic_partition.partition} from #{replicas} to #{new_replicas}" if @log_plan
           plan += Scala::Tuple.new(topic_partition, new_replicas)
         end
       end

--- a/lib/ktl/migration_plan.rb
+++ b/lib/ktl/migration_plan.rb
@@ -11,6 +11,11 @@ module Ktl
       elsif (@from_brokers + @to_brokers).uniq.length != @from_brokers.length * 2
         raise "Broker lists must be mutually exclusive. From: #{@from_brokers}, To: #{@to_brokers}"
       end
+      from_racks = from_brokers.map {|broker_id| Kafka::Admin.get_broker_rack(zk_client, broker_id)}
+      to_racks = to_brokers.map {|broker_id| Kafka::Admin.get_broker_rack(zk_client, broker_id)}
+      if from_racks != to_racks
+        raise "Both broker lists must have the same rack setup. From: #{from_racks}, To: #{to_racks}"
+      end
       @logger = options[:logger] || NullLogger.new
       @log_plan = !!options[:log_plan]
     end

--- a/lib/ktl/migration_plan.rb
+++ b/lib/ktl/migration_plan.rb
@@ -7,14 +7,14 @@ module Ktl
       @from_brokers = from_brokers
       @to_brokers = to_brokers
       if @from_brokers.length != @to_brokers.length
-        raise "Both brokers lists must be of equal length. From: #{@from_brokers}, To: #{@to_brokers}"
+        raise ArgumentError, "Both brokers lists must be of equal length. From: #{@from_brokers}, To: #{@to_brokers}"
       elsif !(@from_brokers & @to_brokers).empty?
-        raise "Broker lists must be mutually exclusive. From: #{@from_brokers}, To: #{@to_brokers}"
+        raise ArgumentError, "Broker lists must be mutually exclusive. From: #{@from_brokers}, To: #{@to_brokers}"
       end
       from_racks = from_brokers.map {|broker_id| Kafka::Admin.get_broker_rack(zk_client, broker_id)}
       to_racks = to_brokers.map {|broker_id| Kafka::Admin.get_broker_rack(zk_client, broker_id)}
       if from_racks != to_racks
-        raise "Both broker lists must have the same rack setup. From: #{from_racks}, To: #{to_racks}"
+        raise ArgumentError, "Both broker lists must have the same rack setup. From: #{from_racks}, To: #{to_racks}"
       end
       @logger = options[:logger] || NullLogger.new
       @log_plan = !!options[:log_plan]

--- a/lib/ktl/reassigner.rb
+++ b/lib/ktl/reassigner.rb
@@ -48,6 +48,12 @@ module Ktl
     JSON_MAX_SIZE = 1024**2
 
     def reassign(reassignment)
+      if (limit)
+        @logger.info 'reassigning %d of %d partitions' % [limit, reassignment.size]
+      else
+        @logger.info 'reassigning %d partitions' % reassignment.size
+      end
+
       reassignments = split(reassignment, @limit)
       reassignment_candidates = reassignments.shift
       actual_reassignment = Scala::Collection::Map.empty
@@ -59,11 +65,11 @@ module Ktl
           actual_reassignment += Scala::Tuple.new(topic_and_partition, step1_replicas)
           brokers = Scala::Collection::JavaConversions.as_java_iterable(step1_replicas).to_a
           eventual_brokers = Scala::Collection::JavaConversions.as_java_iterable(replicas).to_a
-          @logger.info "Mirroring #{topic_and_partition.topic},#{topic_and_partition.partition} to #{brokers.join(',')}, for eventual transition to #{eventual_brokers.join(',')}" if @log_assignments
+          @logger.debug "Mirroring #{topic_and_partition.topic},#{topic_and_partition.partition} to #{brokers.join(',')} for eventual transition to #{eventual_brokers.join(',')}" if @log_assignments
         else
           actual_reassignment += pr
           brokers = Scala::Collection::JavaConversions.as_java_iterable(replicas).to_a
-          @logger.info "Assigning #{topic_and_partition.topic},#{topic_and_partition.partition} to #{brokers.join(',')}" if @log_assignments
+          @logger.debug "Assigning #{topic_and_partition.topic},#{topic_and_partition.partition} to #{brokers.join(',')}" if @log_assignments
         end
       end
       json = reassignment_json(actual_reassignment)

--- a/lib/ktl/reassigner.rb
+++ b/lib/ktl/reassigner.rb
@@ -40,24 +40,56 @@ module Ktl
     end
 
     def execute(reassignment)
-      reassignments = split(reassignment, @limit)
-      actual_reassignment = reassignments.shift
-      if @log_assignments
-        Scala::Collection::JavaConversions.as_java_iterable(actual_reassignment).each do |pr|
-          topic_and_partition, replicas = pr.elements
-          brokers = Scala::Collection::JavaConversions.as_java_iterable(replicas).to_a
-          @logger.info "Assigning #{topic_and_partition.topic},#{topic_and_partition.partition} to #{brokers.join(',')}"
-        end
-      end
-      json = reassignment_json(actual_reassignment)
-      @zk_client.reassign_partitions(json)
-      manage_overflow(reassignments)
-      manage_progress_state(actual_reassignment)
+      reassign(reassignment)
     end
 
     private
 
     JSON_MAX_SIZE = 1024**2
+
+    def reassign(reassignment)
+      reassignments = split(reassignment, @limit)
+      reassignment_candidates = reassignments.shift
+      actual_reassignment = Scala::Collection::Map.empty
+      next_step_assignments = Scala::Collection::Map.empty
+      Scala::Collection::JavaConversions.as_java_iterable(reassignment_candidates).each do |pr|
+        topic_and_partition, replicas = pr.elements
+        if step1_replicas = is_two_step_operation(topic_and_partition, replicas)
+          next_step_assignments += pr
+          actual_reassignment += Scala::Tuple.new(topic_and_partition, step1_replicas)
+          brokers = Scala::Collection::JavaConversions.as_java_iterable(step1_replicas).to_a
+          eventual_brokers = Scala::Collection::JavaConversions.as_java_iterable(replicas).to_a
+          @logger.info "Mirroring #{topic_and_partition.topic},#{topic_and_partition.partition} to #{brokers.join(',')}, for eventual transition to #{eventual_brokers.join(',')}" if @log_assignments
+        else
+          actual_reassignment += pr
+          brokers = Scala::Collection::JavaConversions.as_java_iterable(replicas).to_a
+          @logger.info "Assigning #{topic_and_partition.topic},#{topic_and_partition.partition} to #{brokers.join(',')}" if @log_assignments
+        end
+      end
+      json = reassignment_json(actual_reassignment)
+      @zk_client.reassign_partitions(json)
+      manage_overflow(split(next_step_assignments, nil) + reassignments)
+      manage_progress_state(actual_reassignment)
+    end
+
+    def is_two_step_operation(topic_and_partition, final_replicas)
+      replicas = Scala::Collection::JavaConversions.as_java_iterable(final_replicas).to_a
+      topic_list = Scala::Collection::JavaConversions.as_scala_iterable([topic_and_partition.topic])
+      assignments = ScalaEnumerable.new(@zk_client.replica_assignment_for_topics(topic_list))
+      assignments.each do |item|
+        item_topic_partition = item.first
+        if item_topic_partition.partition == topic_and_partition.partition
+          item_replicas = Scala::Collection::JavaConversions.as_java_iterable(item.last).to_a
+          diff_replicas = replicas - item_replicas
+          unless diff_replicas.empty?
+            transition_replicas = replicas + diff_replicas
+            return Scala::Collection::JavaConversions.as_scala_iterable(transition_replicas)
+          end
+        end
+      end
+
+      false
+    end
 
     def manage_progress_state(reassignment)
       delete_previous_state

--- a/lib/ktl/reassignment_task.rb
+++ b/lib/ktl/reassignment_task.rb
@@ -26,11 +26,6 @@ module Ktl
           reassignment = @plan.generate
         end
         if reassignment.size > 0
-          if (limit = @reassigner.limit)
-            @logger.info 'reassigning %d of %d partitions' % [limit, reassignment.size]
-          else
-            @logger.info 'reassigning %d partitions' % reassignment.size
-          end
           if dryrun
             @logger.info 'dryrun detected, skipping reassignment'
           else

--- a/lib/ktl/shuffle_plan.rb
+++ b/lib/ktl/shuffle_plan.rb
@@ -125,21 +125,7 @@ module Ktl
     private
 
     def rack_for(broker_id)
-      unless @rack_mappings[broker_id]
-        broker_metadata = Kafka::Admin.get_broker_metadatas(@zk_client, [broker_id]).first
-        rack = broker_metadata.rack
-        unless rack.isDefined
-          raise "Broker #{broker_metadata.id} is missing rack information, unable to create rack aware shuffle plan."
-        end
-        @rack_mappings[broker_id] = rack.get
-      end
-      @rack_mappings[broker_id]
-    rescue Java::KafkaAdmin::AdminOperationException => e
-      if e.message.match '--disable-rack-aware'
-        raise "Not all brokers have rack information. Unable to create rack aware shuffle plan."
-      else
-        raise e
-      end
+      @rack_mappings[broker_id] ||= Kafka::Admin.get_broker_rack(@zk_client, broker_id)
     end
   end
 end

--- a/spec/integration/ktl_cluster_spec.rb
+++ b/spec/integration/ktl_cluster_spec.rb
@@ -82,9 +82,7 @@ describe 'bin/ktl cluster' do
         end
 
         it 'uses the overflow data' do
-          expect(final_state).to match [
-            a_hash_including('topic' => 'topic1', 'partition' => 0, 'replicas' => [1])
-          ]
+          expect(final_state).to include(a_hash_including('topic' => 'topic1', 'partition' => 0, 'replicas' => [1]))
         end
       end
 
@@ -182,12 +180,8 @@ describe 'bin/ktl cluster' do
     context 'when given a topic regexp' do
       it 'only includes matched topics' do
         silence { run(%w[cluster preferred-replica ^topic1$], zk_args) }
-        expect(final_state).to match [
-          a_hash_including('topic' => 'topic1', 'partition' => 0)
-        ]
-        expect(final_state).to_not match [
-          a_hash_including('topic' => 'topic2', 'partition' => 0)
-        ]
+        expect(final_state).to include(a_hash_including('topic' => 'topic1', 'partition' => 0))
+        expect(final_state).to_not include(a_hash_including('topic' => 'topic2', 'partition' => 0))
       end
     end
 
@@ -218,9 +212,7 @@ describe 'bin/ktl cluster' do
     context 'when given a topic regexp' do
       it 'only includes matched topics' do
         silence { run(%w[cluster shuffle ^topic1$], zk_args) }
-        expect(final_state).to match [
-          a_hash_including('topic' => 'topic1')
-        ]
+        expect(final_state).to include(a_hash_including('topic' => 'topic1'))
       end
     end
 

--- a/spec/integration/ktl_cluster_spec.rb
+++ b/spec/integration/ktl_cluster_spec.rb
@@ -129,6 +129,13 @@ describe 'bin/ktl cluster' do
       ]
     end
 
+    let :duplicated_partitions do
+      [
+        a_hash_including('topic' => 'topic1', 'partition' => 0, 'replicas' => [0, 1]),
+        a_hash_including('topic' => 'topic2', 'partition' => 0, 'replicas' => [0, 1]),
+      ]
+    end
+
     before do
       %w[topic1 topic2].each do |topic|
         create_topic(topic)
@@ -139,6 +146,11 @@ describe 'bin/ktl cluster' do
     it 'kick-starts a reassignment command for migrating partitions' do
       silence { run(%w[cluster migrate-broker], command_args + zk_args) }
       expect(final_state).to contain_exactly(*reassigned_partitions)
+    end
+
+    it 'duplicates the migrating broker in the first step' do
+      silence { run(%w[cluster migrate-broker], command_args + zk_args) }
+      expect(partitions).to contain_exactly(*duplicated_partitions)
     end
 
     include_examples 'overflow znodes'

--- a/spec/ktl/continous_reassigner_spec.rb
+++ b/spec/ktl/continous_reassigner_spec.rb
@@ -10,7 +10,7 @@ module Ktl
     end
 
     let :zk_client do
-      double(:zk_client)
+      double(:zk_client, replica_assignment_for_topics: Scala::Collection::Map.empty)
     end
 
     let :options do

--- a/spec/ktl/migration_plan_spec.rb
+++ b/spec/ktl/migration_plan_spec.rb
@@ -6,19 +6,19 @@ require 'spec_helper'
 module Ktl
   describe MigrationPlan do
     let :plan do
-      described_class.new(zk_client, old_leader, new_leader).generate
+      described_class.new(zk_client, old_leaders, new_leaders).generate
     end
 
     let :zk_client do
       double(:zk_client)
     end
 
-    let :old_leader do
-      0
+    let :old_leaders do
+      [0]
     end
 
-    let :new_leader do
-      1
+    let :new_leaders do
+      [1]
     end
 
     let :assignment do
@@ -33,6 +33,7 @@ module Ktl
         topics = scala_list(%w[test-topic-1])
         allow(zk_client).to receive(:all_topics).and_return(topics)
         allow(zk_client).to receive(:replica_assignment_for_topics).with(topics).and_return(assignment)
+        allow(Kafka::Admin).to receive(:get_broker_rack).and_return('rack')
       end
 
       it 'returns an object with topic-partitions <-> new AR mappings' do

--- a/spec/ktl/reassigner_spec.rb
+++ b/spec/ktl/reassigner_spec.rb
@@ -29,7 +29,7 @@ module Ktl
       context 'if there\'s a reassignment in progress' do
         let :reassignment do
           r = Scala::Collection::Map.empty
-          2.times.map do |partition|
+          2.times.each do |partition|
             topic_partition = Kafka::TopicAndPartition.new('topic1', partition)
             replicas = scala_int_list([0, 1])
             r += Scala::Tuple.new(topic_partition, replicas)
@@ -92,7 +92,7 @@ module Ktl
     describe '#load_overflow' do
       let :overflow_part_1 do
         r = Scala::Collection::Map.empty
-        2.times.map do |partition|
+        2.times.each do |partition|
           topic_partition = Kafka::TopicAndPartition.new('topic1', partition)
           replicas = scala_int_list([0, 1, 2])
           r += Scala::Tuple.new(topic_partition, replicas)
@@ -102,7 +102,7 @@ module Ktl
 
       let :overflow_part_2 do
         r = Scala::Collection::Map.empty
-        2.times.map do |partition|
+        2.times.each do |partition|
           topic_partition = Kafka::TopicAndPartition.new('topic2', partition)
           replicas = scala_int_list([0, 1, 2])
           r += Scala::Tuple.new(topic_partition, replicas)
@@ -159,7 +159,7 @@ module Ktl
       context 'when the reassignment is less than 1MB' do
         let :reassignment do
           r = Scala::Collection::Map.empty
-          10.times.map do |partition|
+          10.times.each do |partition|
             topic_partition = Kafka::TopicAndPartition.new('topic1', partition)
             replicas = scala_int_list([0, 1, 2])
             r += Scala::Tuple.new(topic_partition, replicas)
@@ -246,7 +246,7 @@ module Ktl
 
         let :reassignment do
           r = Scala::Collection::Map.empty
-          100.times.map do |partition|
+          100.times.each do |partition|
             topic_partition = Kafka::TopicAndPartition.new('topic1', partition)
             replicas = scala_int_list([0, 1, 2])
             r += Scala::Tuple.new(topic_partition, replicas)
@@ -284,7 +284,7 @@ module Ktl
       context 'with a current assignment' do
         let :reassignment do
           r = Scala::Collection::Map.empty
-          10.times.map do |partition|
+          10.times.each do |partition|
             topic_partition = Kafka::TopicAndPartition.new('topic1', partition)
             replicas = scala_int_list([0, 2])
             r += Scala::Tuple.new(topic_partition, replicas)
@@ -294,7 +294,7 @@ module Ktl
 
         let :current_assignment do
           r = Scala::Collection::Map.empty
-          10.times.map do |partition|
+          10.times.each do |partition|
             topic_partition = Kafka::TopicAndPartition.new('topic1', partition)
             replicas = scala_int_list([0, 1])
             r += Scala::Tuple.new(topic_partition, replicas)
@@ -304,7 +304,7 @@ module Ktl
 
         let :duplicated_reassignment do
           r = Scala::Collection::Map.empty
-          10.times.map do |partition|
+          10.times.each do |partition|
             topic_partition = Kafka::TopicAndPartition.new('topic1', partition)
             replicas = scala_int_list([0, 1, 2])
             r += Scala::Tuple.new(topic_partition, replicas)

--- a/spec/ktl/reassigner_spec.rb
+++ b/spec/ktl/reassigner_spec.rb
@@ -10,7 +10,7 @@ module Ktl
     end
 
     let :zk_client do
-      double(:zk_client)
+      double(:zk_client, replica_assignment_for_topics: Scala::Collection::Map.empty)
     end
 
     let :zk_utils do

--- a/spec/ktl/shuffle_plan_spec.rb
+++ b/spec/ktl/shuffle_plan_spec.rb
@@ -239,7 +239,7 @@ module Ktl
         index = broker_id % 10
         double("broker_#{index}", id: broker_id).tap do |broker|
           rack_name = "rack-#{index}"
-          rack = double(rack_name, isDefined: true, get: rack_name)
+          rack = double(rack_name, defined?: true, get: rack_name)
           allow(broker).to receive(:rack).and_return(rack)
         end
       end
@@ -317,7 +317,7 @@ module Ktl
 
         it 'raises exception if broker is missing rack configuration' do
           broker_metadata = generate_broker_metadata(203)
-          allow(broker_metadata.rack).to receive(:isDefined).and_return(false)
+          allow(broker_metadata.rack).to receive(:defined?).and_return(false)
           expect { plan.generate }.to raise_error /Broker 203 is missing rack information/
         end
       end

--- a/spec/support/integration.rb
+++ b/spec/support/integration.rb
@@ -35,14 +35,15 @@ shared_context 'integration setup' do
     key ? d[key] : d
   end
 
-  def register_broker(id, name='localhost')
+  def register_broker(id, rack = nil)
+    rack ||= "rack#{id}"
     endpoint_tuple = Scala::Tuple.new(
       Kafka::Protocol::SecurityProtocol.for_name('PLAINTEXT'),
-      Kafka::Cluster::EndPoint.create_end_point("PLAINTEXT://#{name}:9092")
+      Kafka::Cluster::EndPoint.create_end_point("PLAINTEXT://localhost:9092")
     )
     endpoints = Scala::Collection::Map.empty
     endpoints += endpoint_tuple
-    ktl_zk.register_broker_in_zk(id, name, 9092, endpoints, 57476, Scala::Option["rack#{id}"], Kafka::Api::ApiVersion.apply('0.10.0.1'))
+    ktl_zk.register_broker_in_zk(id, "localhost", 9092, endpoints, 57476, Scala::Option[rack], Kafka::Api::ApiVersion.apply('0.10.0.1'))
   end
 
   def clear_zk_chroot


### PR DESCRIPTION
This pull request changes the way that broker reassignments are handled. If a partition is reassigned away from a broker, the reassignment is split into two operations:
1. Duplicate partition onto the new broker
2. Remove partition from the old broker

Since the logic for this is placed in the `Reassigner`, this will impact all broker migration operations, including `shuffle`, `migrate-broker` and `decommission-broker`.

As a small bonus, this PR also improves on `migrate-broker` by allowing enabling migration of multiple brokers at the same time.