### PR TITLE
Fixes to multi step migration and shuffle plan

### DIFF
--- a/lib/ext/kafka.rb
+++ b/lib/ext/kafka.rb
@@ -133,11 +133,13 @@ module Kafka
 
     def self.get_broker_rack(zk_client, broker_id)
       broker_metadata = Kafka::Admin.get_broker_metadatas(zk_client, [broker_id]).first
-      rack = broker_metadata.rack
-      unless rack.defined?
-        raise "Broker #{broker_metadata.id} is missing rack information, unable to create rack aware shuffle plan."
+      if broker_metadata
+        rack = broker_metadata.rack
+        unless rack.defined?
+          raise "Broker #{broker_metadata.id} is missing rack information, unable to create rack aware shuffle plan."
+        end
+        rack.get
       end
-      rack.get
     rescue Java::KafkaAdmin::AdminOperationException => e
       if e.message.include? '--disable-rack-aware'
         raise "Not all brokers have rack information. Unable to create rack aware shuffle plan."

--- a/lib/ktl/cluster.rb
+++ b/lib/ktl/cluster.rb
@@ -36,6 +36,7 @@ module Ktl
     option :dryrun, aliases: %w[-d], desc: 'Output reassignment plan without executing'
     option :wait, aliases: %w[-w], type: :boolean, desc: 'Wait for all reassignments to finish'
     option :delay, type: :numeric, desc: 'Delay in seconds between continous reassignment iterations, default 5s'
+    option :multi_step_migration, type: :boolean, default: true, desc: 'Perform migration in multiple steps, mirroring partitions to new brokers before removing the old'
     def migrate_broker
       with_zk_client do |zk_client|
         old_brokers, new_brokers = options.values_at(:from, :to)
@@ -57,6 +58,7 @@ module Ktl
     option :dryrun, aliases: %w[-d], desc: 'Output reassignment plan without executing'
     option :wait, aliases: %w[-w], type: :boolean, desc: 'Wait for all reassignments to finish'
     option :delay, type: :numeric, desc: 'Delay in seconds between continous reassignment iterations, default 5s'
+    option :multi_step_migration, type: :boolean, default: true, desc: 'Perform migration in multiple steps, mirroring partitions to new brokers before removing the old'
     def shuffle(regexp='.*')
       with_zk_client do |zk_client|
         plan_factory = if options.rack_aware
@@ -117,9 +119,9 @@ module Ktl
 
     def create_reassigner(zk_client, options)
       if options.wait?
-        ContinousReassigner.new(zk_client, limit: options.limit, logger: logger, log_assignments: options.verbose, delay: options.delay, shell: shell)
+        ContinousReassigner.new(zk_client, limit: options.limit, logger: logger, log_assignments: options.verbose, delay: options.delay, shell: shell, multi_step_migration: options.multi_step_migration)
       else
-        Reassigner.new(zk_client, limit: options.limit, logger: logger, log_assignments: options.verbose)
+        Reassigner.new(zk_client, limit: options.limit, logger: logger, log_assignments: options.verbose, multi_step_migration: options.multi_step_migration)
       end
     end
   end

--- a/lib/ktl/migration_plan.rb
+++ b/lib/ktl/migration_plan.rb
@@ -13,7 +13,7 @@ module Ktl
       end
       from_racks = from_brokers.map {|broker_id| Kafka::Admin.get_broker_rack(zk_client, broker_id)}
       to_racks = to_brokers.map {|broker_id| Kafka::Admin.get_broker_rack(zk_client, broker_id)}
-      if from_racks != to_racks
+      if from_racks != to_racks && from_racks.compact.any?
         raise ArgumentError, "Both broker lists must have the same rack setup. From: #{from_racks}, To: #{to_racks}"
       end
       @logger = options[:logger] || NullLogger.new

--- a/lib/ktl/reassigner.rb
+++ b/lib/ktl/reassigner.rb
@@ -12,6 +12,7 @@ module Ktl
       @state_path = '/ktl/reassign'
       @logger = options[:logger] || NullLogger.new
       @log_assignments = !!options[:log_assignments]
+      @multi_step_migration = options[:multi_step_migration]
     end
 
     def reassignment_in_progress?
@@ -60,7 +61,7 @@ module Ktl
       next_step_assignments = Scala::Collection::Map.empty
       Scala::Collection::JavaConversions.as_java_iterable(reassignment_candidates).each do |pr|
         topic_and_partition, replicas = pr.elements
-        if step1_replicas = is_two_step_operation(topic_and_partition, replicas)
+        if @multi_step_migration && step1_replicas = is_two_step_operation(topic_and_partition, replicas)
           if step1_replicas.uniq != step1_replicas
             raise "Multiple replicas on the same broker, this should not happen... #{step1_replicas}"
           end

--- a/spec/integration/ktl_cluster_spec.rb
+++ b/spec/integration/ktl_cluster_spec.rb
@@ -117,7 +117,7 @@ describe 'bin/ktl cluster' do
     end
 
     let :command_args do
-      %w[--from 0 --to 1]
+      %w[--from 0 --to 1 --multi_step_migration]
     end
 
     let :reassigned_partitions do

--- a/spec/ktl/reassigner_spec.rb
+++ b/spec/ktl/reassigner_spec.rb
@@ -281,7 +281,13 @@ module Ktl
         end
       end
 
-      context 'with a current assignment' do
+      context 'with multi step assignment' do
+        let :options do
+          {
+            multi_step_migration: true
+          }
+        end
+
         let :reassignment do
           r = Scala::Collection::Map.empty
           10.times.each do |partition|

--- a/spec/ktl/shuffle_plan_spec.rb
+++ b/spec/ktl/shuffle_plan_spec.rb
@@ -323,6 +323,21 @@ module Ktl
           expect { plan.generate }.to raise_error /Broker 203 is missing rack information/
         end
       end
+
+      context 'with broker missing rack' do
+        let :brokers do
+          [101, 102, 103]
+        end
+
+        before do
+          rack = Scala::Option.apply(nil.to_java)
+          @brokers[101] = Kafka::Admin::BrokerMetadata.new(101, rack)
+        end
+
+        it 'raises exception' do
+          expect { plan.generate }.to raise_error(RuntimeError, /Broker 101 is missing rack information/)
+        end
+      end
     end
   end
 end

--- a/spec/ktl/shuffle_plan_spec.rb
+++ b/spec/ktl/shuffle_plan_spec.rb
@@ -10,7 +10,11 @@ module Ktl
     end
 
     let :zk_client do
-      double(:zk_client)
+      double(:zk_client, utils: zk_utils)
+    end
+
+    let :zk_utils do
+      double(:zk_utils)
     end
 
     let :options do
@@ -31,6 +35,29 @@ module Ktl
         'topic2' => [brokers[0, replica_count].reverse, brokers[0, replica_count].reverse],
         'topic3' => [brokers.reverse[0, replica_count], brokers.reverse[0, replica_count]],
       }
+    end
+
+    let :zk_utils do
+      double(:zk_utils)
+    end
+
+    def generate_broker_metadata(broker_id)
+      @brokers[broker_id] ||= begin
+        index = broker_id % 10
+        rack_name = "rack-#{index}"
+        rack = Scala::Option.apply(rack_name.to_java)
+        Kafka::Admin::BrokerMetadata.new(broker_id, rack)
+      end
+    end
+
+    before do
+      @brokers = {}
+      allow(zk_client).to receive(:utils).and_return(zk_utils)
+      allow(Kafka::Admin).to receive(:get_broker_metadatas) do |zk_client, broker_list|
+        broker_list.map do |broker|
+          generate_broker_metadata(broker)
+        end
+      end
     end
 
     before do
@@ -230,31 +257,6 @@ module Ktl
   end
 
   describe RackAwareShufflePlan do
-    let :zk_utils do
-      double(:zk_utils)
-    end
-
-    def generate_broker_metadata(broker_id)
-      @brokers[broker_id] ||= begin
-        index = broker_id % 10
-        double("broker_#{index}", id: broker_id).tap do |broker|
-          rack_name = "rack-#{index}"
-          rack = double(rack_name, defined?: true, get: rack_name)
-          allow(broker).to receive(:rack).and_return(rack)
-        end
-      end
-    end
-
-    before do
-      @brokers = {}
-      allow(zk_client).to receive(:utils).and_return(zk_utils)
-      allow(Kafka::Admin).to receive(:get_broker_metadatas) do |zk_client, broker_list|
-        broker_list.map do |broker|
-          generate_broker_metadata(broker)
-        end
-      end
-    end
-
     describe '#generate' do
       include_examples 'a shuffle plan'
 


### PR DESCRIPTION
This PR fixes a few minor things I've discovered while working on some new shuffle plans:

- Adds `--no-multi-step-migration` to `shuffle` and `migrate-broker` to disable the multi step migration. Multi step migration is for example impossible if a broker is offline.
- Fixes `migrate-broker` when source broker is offline, by making sure `get_broker_rack` doesn't raise errors.
- Ensure real `BrokerMetadata` when using `ShufflePlan`, ensuring distribution is rack aware if configured.